### PR TITLE
fix tide tridents

### DIFF
--- a/src/main/java/com/infamous/dungeons_mobs/MobEvents.java
+++ b/src/main/java/com/infamous/dungeons_mobs/MobEvents.java
@@ -18,7 +18,10 @@ import com.infamous.dungeons_mobs.entities.summonables.ConstructEntity;
 import com.infamous.dungeons_mobs.entities.undead.FrozenZombieEntity;
 import com.infamous.dungeons_mobs.goals.AvoidBaseEntityGoal;
 import com.infamous.dungeons_mobs.goals.SmartTridentAttackGoal;
+import com.infamous.dungeons_mobs.interfaces.IHasItemStackData;
 import com.infamous.dungeons_mobs.mixin.GoalSelectorAccessor;
+import com.infamous.dungeons_mobs.mixin.TridentEntityAccessor;
+import com.infamous.dungeons_mobs.mixin.TridentEntityMixin;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.goal.AvoidEntityGoal;
 import net.minecraft.entity.ai.goal.RangedAttackGoal;
@@ -26,6 +29,7 @@ import net.minecraft.entity.item.ArmorStandEntity;
 import net.minecraft.entity.monster.DrownedEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.SnowballEntity;
+import net.minecraft.entity.projectile.TridentEntity;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.tags.FluidTags;
@@ -126,6 +130,9 @@ public class MobEvents {
             DrownedEntity drownedEntity = (DrownedEntity) event.getEntity();
             ((GoalSelectorAccessor)drownedEntity.goalSelector).getAvailableGoals().removeIf(pg -> pg.getPriority() == 2 && pg.getGoal() instanceof RangedAttackGoal);
             drownedEntity.goalSelector.addGoal(2, new SmartTridentAttackGoal(drownedEntity, 1.0D, 40, 10.0F));
+        }
+        if(event.getEntity() instanceof TridentEntity){
+            ((IHasItemStackData)event.getEntity()).setDataItem(((TridentEntityAccessor) event.getEntity()).getTridentItem());
         }
     }
 

--- a/src/main/java/com/infamous/dungeons_mobs/mixin/TridentEntityAccessor.java
+++ b/src/main/java/com/infamous/dungeons_mobs/mixin/TridentEntityAccessor.java
@@ -1,0 +1,26 @@
+package com.infamous.dungeons_mobs.mixin;
+
+import com.infamous.dungeons_mobs.interfaces.IHasItemStackData;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.AbstractArrowEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.network.datasync.DataParameter;
+import net.minecraft.network.datasync.DataSerializers;
+import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TridentEntity.class)
+public interface TridentEntityAccessor {
+    @Accessor
+    ItemStack getTridentItem();
+}

--- a/src/main/java/com/infamous/dungeons_mobs/mixin/TridentEntityMixin.java
+++ b/src/main/java/com/infamous/dungeons_mobs/mixin/TridentEntityMixin.java
@@ -13,6 +13,7 @@ import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -60,4 +61,7 @@ public abstract class TridentEntityMixin extends AbstractArrowEntity  implements
     public void setDataItem(ItemStack dataItem) {
         this.entityData.set(DATA_ITEM_STACK, dataItem);
     }
+
+    @Accessor
+    public abstract ItemStack getTridentItem();
 }

--- a/src/main/resources/dungeons_mobs.mixins.json
+++ b/src/main/resources/dungeons_mobs.mixins.json
@@ -18,6 +18,7 @@
     "PiglinEntityMixin",
     "RaidMixin",
     "SpiderEntityMixin",
+    "TridentEntityAccessor",
     "TridentEntityMixin",
     "WitherSkeletonEntityMixin",
     "ZombifiedPiglinEntityMixin"


### PR DESCRIPTION
retroactively update the trident's identity as it enters the world. Seems to survive save-loading just fine.