### PR TITLE
Fix compability with MineColonies' farmer

### DIFF
--- a/src/main/java/com/infamous/dungeons_mobs/entities/EntityEvents.java
+++ b/src/main/java/com/infamous/dungeons_mobs/entities/EntityEvents.java
@@ -64,7 +64,7 @@ public class EntityEvents {
 	public static void preventBlockBreaking(BreakEvent event) {
 		Player owner = event.getPlayer();
 		
-		if (owner.hasEffect(ENSNARED.get())) {
+		if (owner != null && owner.hasEffect(ENSNARED.get())) {
 			// Prevent crashes, cause sometimes it isn't cancellable
 			if (event.isCancelable()) event.setCanceled(true);
 		}
@@ -85,7 +85,7 @@ public class EntityEvents {
 	public static void preventBlockInteraction(BlockToolModificationEvent event) {
 		Player owner = event.getPlayer();
 		
-		if (owner.hasEffect(ENSNARED.get())) {
+		if (owner != null && owner.hasEffect(ENSNARED.get())) {
 			if (event.isCancelable()) event.setCanceled(true);
 		}
 	}


### PR DESCRIPTION
Fixes the following issue caused by MineColonies' farmer attempting to interact with block.

```
[198月2024 01:47:43.648] [Server thread/ERROR] [net.minecraftforge.eventbus.EventBus/EVENTBUS]: Exception caught during firing event: Cannot invoke "net.minecraft.world.entity.player.Player.m_21023_(net.minecraft.world.effect.MobEffect)" because "owner" is null
	Index: 2
	Listeners:
		0: NORMAL
		1: ASM: class com.legacy.blue_skies.events.SkiesPlayerEvents onToolUse(Lnet/minecraftforge/event/level/BlockEvent$BlockToolModificationEvent;)V
		2: ASM: class com.infamous.dungeons_mobs.entities.EntityEvents preventBlockInteraction(Lnet/minecraftforge/event/level/BlockEvent$BlockToolModificationEvent;)V
		3: ASM: class net.mehvahdjukaar.supplementaries.common.events.forge.ServerEventsForge toolModification(Lnet/minecraftforge/event/level/BlockEvent$BlockToolModificationEvent;)V
		4: ASM: class vazkii.quark.base.handler.ToolInteractionHandler toolActionEvent(Lnet/minecraftforge/event/level/BlockEvent$BlockToolModificationEvent;)V
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.player.Player.m_21023_(net.minecraft.world.effect.MobEffect)" because "owner" is null
	at TRANSFORMER/dungeons_mobs@1.19.2-4.0.8-beta/com.infamous.dungeons_mobs.entities.EntityEvents.preventBlockInteraction(EntityEvents.java:88)
	at TRANSFORMER/dungeons_mobs@1.19.2-4.0.8-beta/com.infamous.dungeons_mobs.entities.__EntityEvents_preventBlockInteraction_BlockToolModificationEvent.invoke(.dynamic)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:73)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:315)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:296)
	at TRANSFORMER/forge@43.3.7/net.minecraftforge.event.ForgeEventFactory.onToolUse(ForgeEventFactory.java:328)
	at TRANSFORMER/forge@43.3.7/net.minecraftforge.common.extensions.IForgeBlockState.getToolModifiedState(IForgeBlockState.java:660)
	at TRANSFORMER/minecolonies_compatibility@1.33/steve_gall.minecolonies_compatibility.core.common.block.BlockUtils.getToolModifiedState(BlockUtils.java:30)
	at TRANSFORMER/minecolonies_compatibility@1.33/steve_gall.minecolonies_compatibility.core.common.block.BlockUtils.getHoeTilledState(BlockUtils.java:22)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.citizen.farmer.EntityAIWorkFarmer.handler$bei000$findHoeableSurface_TAIL(EntityAIWorkFarmer.java:2137)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.citizen.farmer.EntityAIWorkFarmer.findHoeableSurface(EntityAIWorkFarmer.java:363)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.citizen.farmer.EntityAIWorkFarmer.lambda$prepareForFarming$1(EntityAIWorkFarmer.java:264)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.citizen.farmer.EntityAIWorkFarmer.checkIfShouldExecute(EntityAIWorkFarmer.java:308)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.citizen.farmer.EntityAIWorkFarmer.prepareForFarming(EntityAIWorkFarmer.java:264)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicTransition.getNextState(BasicTransition.java:79)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicStateMachine.transitionToNext(BasicStateMachine.java:163)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicStateMachine.checkTransition(BasicStateMachine.java:149)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine.checkTransition(TickRateStateMachine.java:133)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine.tick(TickRateStateMachine.java:109)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.basic.AbstractAISkeleton.tick(AbstractAISkeleton.java:61)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.ai.citizen.CitizenAI.lambda$registerWorkAI$4(CitizenAI.java:96)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicTransition.getNextState(BasicTransition.java:79)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicStateMachine.transitionToNext(BasicStateMachine.java:163)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicStateMachine.checkTransition(BasicStateMachine.java:149)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine.checkTransition(TickRateStateMachine.java:133)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine.tick(TickRateStateMachine.java:109)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.citizen.EntityCitizen.lambda$new$11(EntityCitizen.java:295)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicTransition.checkCondition(BasicTransition.java:87)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicStateMachine.checkTransition(BasicStateMachine.java:138)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine.checkTransition(TickRateStateMachine.java:133)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine.tick(TickRateStateMachine.java:109)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.citizen.AbstractEntityCitizen.m_8107_(AbstractEntityCitizen.java:434)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.core.entity.citizen.EntityCitizen.m_8107_(EntityCitizen.java:734)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.world.entity.LivingEntity.m_8119_(LivingEntity.java:2291)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.world.entity.Mob.m_8119_(Mob.java:318)
	at TRANSFORMER/minecolonies@1.19.2-1.1.628-BETA/com.minecolonies.api.entity.citizen.AbstractCivilianEntity.m_8119_(AbstractCivilianEntity.java:88)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:658)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.world.level.Level.m_46653_(Level.java:457)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:323)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:303)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:866)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:292)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:806)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:654)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:244)
	at java.base/java.lang.Thread.run(Thread.java:833)
```